### PR TITLE
Loosen constraint on http-rb version to >= 3.2

### DIFF
--- a/shrine-cloudinary.gemspec
+++ b/shrine-cloudinary.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "shrine", "~> 2.11"
   gem.add_dependency "cloudinary", "< 2"
   gem.add_dependency "down", "~> 4.4"
-  gem.add_dependency "http", "~> 3.2"
+  gem.add_dependency "http", ">= 3.2"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "minitest"


### PR DESCRIPTION
Currently, we are locked on an old version of http-rp due to shrine-cloudinary. This PR loosens the constraint so users can upgrade to http-rb 4.